### PR TITLE
Add c++ll flag.

### DIFF
--- a/lab4/provided/Makefile
+++ b/lab4/provided/Makefile
@@ -1,3 +1,3 @@
 
 cache_simulator: main.cc cache.cc direct_mapped.cc memory.cc ticked_object.cc processor.cc tag_array.cc non_blocking.cc set_assoc.cc
-	g++ main.cc cache.cc direct_mapped.cc memory.cc ticked_object.cc processor.cc tag_array.cc non_blocking.cc set_assoc.cc -o cache_simulator -g -DDEBUG
+	g++ -std=gnu++11 main.cc cache.cc direct_mapped.cc memory.cc ticked_object.cc processor.cc tag_array.cc non_blocking.cc set_assoc.cc -o cache_simulator -g -DDEBUG


### PR DESCRIPTION
Theres a ton of errors because the compiler doesn't automatically use c++ll. With the flag it works on csif and my mac. I understand that this probably won't get me 5 points..