### PR TITLE
Fixed bounds checking on getTag and getState in tag_array.cc

### DIFF
--- a/lab4/provided/tag_array.cc
+++ b/lab4/provided/tag_array.cc
@@ -18,14 +18,16 @@ TagArray::TagArray(int lines, int state_bits, int tag_bits) :
 uint64_t
 TagArray::getTag(int line)
 {
-    uint64_t tag_mask = ((uint64_t)-1) >> (64 - tagBits);
+    assert(line >= 0);
+    assert(line < tags.size());
     return tags[line];
 }
 
 uint32_t
 TagArray::getState(int line)
 {
-    uint32_t state_mask = ((uint32_t)-1) >> (32 - stateBits);
+    assert(line >= 0);
+    assert(line < states.size());
     return states[line];
 }
 


### PR DESCRIPTION
Kevin Hulen and I both found this inconsistency in tag_array.cc. We noticed that you were masking the tag in getState and getTag without applying in an assertion. It didn't make sense to use masking because tag is never passed into the function and so in place of that, we decided to put bounds checking on the line.