### PR TITLE
Updated README

### DIFF
--- a/lab5/lab5.rst
+++ b/lab5/lab5.rst
@@ -68,7 +68,7 @@ I don't know about tsch, etc.
 
     for i in 10 11 12 13 14
     do
-        ./cache_simulator ../../lab5/long_trace.txt $i 1 | grep Misses
+        ./cache_simulator ../../lab5/long_trace.txt $i 2 4 | grep Misses
     done
 
 

--- a/lab5/lab5.rst
+++ b/lab5/lab5.rst
@@ -68,7 +68,7 @@ I don't know about tsch, etc.
 
     for i in 10 11 12 13 14
     do
-        ./cache_simulator ../../lab5/long_trace.txt $i 2 4 | grep Misses
+        ./cache_simulator ../../lab5/long_trace.txt $i 1 1 | grep Misses
     done
 
 


### PR DESCRIPTION
Shell script was not passing in the correct number of arguments to ./cache_simulator. Looks like the current version takes in 4 arguments. File, cache size, ways, and mshrs.