### PR TITLE
opcode bug?

### DIFF
--- a/lab1/lab1.md
+++ b/lab1/lab1.md
@@ -248,7 +248,7 @@ The following table details the `operation` input and which values produce which
 
 |      |     |
 |------|-----|
-| 0000 | and |
+| 0010 | and |
 | 0001 | or  |
 | 0010 | add |
 | 0011 | sub |


### PR DESCRIPTION
I checked the testercode for ALUcontrol and found out the opcode for add is 0010 and not 0000 as described in the lab, is this an error?
<img width="441" alt="bug2" src="https://user-images.githubusercontent.com/11937494/51153458-1fed1b00-1825-11e9-8526-3effe90fe7bf.png">

![bug1](https://user-images.githubusercontent.com/11937494/51153459-1fed1b00-1825-11e9-881c-b5b555b64ba6.png)
