### PR TITLE
Fix lecture links, correct Markdown sublists

### DIFF
--- a/written/week1.md
+++ b/written/week1.md
@@ -12,21 +12,21 @@ If you'd like answers to the problems, either post on Piazza or go to Jason's or
 
 ## Lectures
 
-1. [Introduction](https://github.com/jlpteaching/ECS154B/blob/master/lecture%20notes/Lecture-1.pdf)
-2. [Technology](https://github.com/jlpteaching/ECS154B/blob/master/lecture%20notes/Lecture-2.pdf)
-3. [More technology](https://github.com/jlpteaching/ECS154B/blob/master/lecture%20notes/Lecture-3.pdf)
+1. [Introduction](https://github.com/jlpteaching/ECS154B/blob/master/lecture%20notes/01-07-Lecture-1.pdf)
+2. [Technology](https://github.com/jlpteaching/ECS154B/blob/master/lecture%20notes/01-09-Lecture-2.pdf)
+3. [More technology](https://github.com/jlpteaching/ECS154B/blob/master/lecture%20notes/01-09-Lecture-3.pdf)
 
 ## Topics covered
 
 * Security
-   * Meltdown and Spectre
-   * Security as a design constraint
+    * Meltdown and Spectre
+    * Security as a design constraint
 * History of computing
-  * Moore's law
-  * Dennard scaling
+    * Moore's law
+    * Dennard scaling
 * CMOS devices
-  * Energy
-  * Power
+    * Energy
+    * Power
 * Trends in computing
 
 ## Problems

--- a/written/week2.md
+++ b/written/week2.md
@@ -12,23 +12,23 @@ If you'd like answers to the problems, either post on Piazza or go to Jason's or
 
 ## Lectures
 
-4. [Instruction sets + RISC-V introduction](https://github.com/jlpteaching/ECS154B/blob/master/lecture%20notes/Lecture-4.pdf)
-5. [Example machine design](https://github.com/jlpteaching/ECS154B/blob/master/lecture%20notes/Lecture-5.pdf)
-6. [Single cycle RISC-V](https://github.com/jlpteaching/ECS154B/blob/master/lecture%20notes/Lecture-6.pdf)
+4. [Instruction sets + RISC-V introduction](https://github.com/jlpteaching/ECS154B/blob/master/lecture%20notes/01-14-Lecture-4.pdf)
+5. [Example machine design](https://github.com/jlpteaching/ECS154B/blob/master/lecture%20notes/01-16-Lecture-5.pdf)
+6. [Single cycle RISC-V](https://github.com/jlpteaching/ECS154B/blob/master/lecture%20notes/01-18-Lecture-6.pdf)
 
 ## Topics covered
 
 * Instruction set architectures (ISAs)
-  * RISC versus CISC
+    * RISC versus CISC
 * RISC-V
-  * Instruction types
-  * Extensions
+    * Instruction types
+    * Extensions
 * From code to execution
-  * Going from higher-level languages to machine code
-  * Executing an instruction
+    * Going from higher-level languages to machine code
+    * Executing an instruction
 * Single-cycle CPU
-  * Datapath
-  * Adding new instructions
+    * Datapath
+    * Adding new instructions
 
 ## Problems
 
@@ -44,18 +44,18 @@ If you'd like answers to the problems, either post on Piazza or go to Jason's or
 
 6. Is RISC-V an implementation of hardware? What about x86 or ARM - are they implementations of hardware?
 7. How many operands does a RISC-V R-type instruction specify? What about an I-type?
-  * (inspired by something I learned after making this document) What type of instruction is `lui` and `auipc`? How does this type differ from an I-type?
-8. What is the difference between the `addi` and `addiw` instructions? Can you run the `addiw` instruction in a processor that implements only the RV32I specification?
+    * (inspired by something I learned after making this document) What type of instruction is `lui` and `auipc`? How does this type differ from an I-type?
+8. What is the difference between the `addi` and `addiw` instructions in RISC-V? Can you run the `addiw` instruction in a processor that implements only the RV32I specification?
 
 ### From code to execution
 
 9. What steps do we take to translate C code into machine code? How does this process differ compared to the process for a language like JavaScript? (Hint: look up the difference between a compiled and an interpreted language.)
 10. Using the following RISC-V assembly, translate the following instructions to machine code. The register numbers have been provided in a comment.
-  * `auipc a0, 0 # (reg[10] = 0 + pc (4))`
-  * `add t0, t0, t1 # reg[5] = reg[5] + reg[6]`
+    * `auipc a0, 0 # (reg[10] = 0 + pc (4))`
+    * `add t0, t0, t1 # reg[5] = reg[5] + reg[6]`
 11. Using the following machine code provided in hex, translate the following machine code to RISC-V assembly mnemonics. You can specify just the register numbers instead of using the standardized names.
-  * `0x00858593`
-  * `0x00e51513`
+    * `0x00858593`
+    * `0x00e51513`
 12. List the five steps to execute an instruction, and what each step does. At what point is the current PC value updated with the address of the next instruction?
 
 ### Single-cycle CPU

--- a/written/week3.md
+++ b/written/week3.md
@@ -13,18 +13,18 @@ If you'd like answers to the problems, either post on Piazza or go to Jason's or
 
 ## Lectures
 
-7. [Performance](https://github.com/jlpteaching/ECS154B/blob/master/lecture%20notes/Lecture-7.pdf)
-8. [Multi-cycle and pipeline introduction](https://github.com/jlpteaching/ECS154B/blob/master/lecture%20notes/Lecture-8.pdf)
-9. [More performance](https://github.com/jlpteaching/ECS154B/blob/master/lecture%20notes/Lecture-9.pdf)
-10. [Review](https://github.com/jlpteaching/ECS154B/blob/master/lecture%20notes/Lecture-10.pdf)
+7. [Performance](https://github.com/jlpteaching/ECS154B/blob/master/lecture%20notes/01-23-Lecture-7.pdf)
+8. [Multi-cycle and pipeline introduction](https://github.com/jlpteaching/ECS154B/blob/master/lecture%20notes/01-25-Lecture-8.pdf)
+9. [More performance](https://github.com/jlpteaching/ECS154B/blob/master/lecture%20notes/01-28-Lecture-9.pdf)
+10. [Review](https://github.com/jlpteaching/ECS154B/blob/master/lecture%20notes/01-30-Lecture-10.pdf)
 
 ## Topics covered
 
 * Performance
-  * Measuring performance
-  * Iron law
-  * Amdahl's law
-  * Latency and throughput
+    * Measuring performance
+    * Iron law
+    * Amdahl's law
+    * Latency and throughput
 * Introduction to pipelining
 
 ## Problems

--- a/written/weeks4-5.md
+++ b/written/weeks4-5.md
@@ -1,0 +1,23 @@
+---
+author: Justin Perona
+title: ECS 154B Written Problems for Weeks 4-5, Winter 2019
+---
+
+# Written problems for weeks 4-5
+
+This problem set covers lectures 11 through 14.
+
+Solutions won't be posted on GitHub.
+If you'd like answers to the problems, either post on Piazza or go to Jason's or Justin's office hours.
+
+## Lectures
+
+11. [](https://github.com/jlpteaching/ECS154B/blob/master/lecture%20notes/02-01-Lecture-11.pdf)
+12. [](https://github.com/jlpteaching/ECS154B/blob/master/lecture%20notes/02-04-Lecture-12.pdf)
+13. [](https://github.com/jlpteaching/ECS154B/blob/master/lecture%20notes/02-06-Lecture-13.pdf)
+14. [](https://github.com/jlpteaching/ECS154B/blob/master/lecture%20notes/02-08-Lecture-14.pdf)
+
+## Topics covered
+
+## Problems
+


### PR DESCRIPTION
Commit ff48a8a changed the names of the lecture notes, so this broke the links in these files. Fix that, along with the correct Markdown syntax for sublists. Also add the shell for the next written homework set.

If you can, can you keep the same naming for the rest of the lecture notes you upload - mm-dd-Lecture-#.md?