### PR TITLE
fix link to discussion section

### DIFF
--- a/syllabus/syllabus.md
+++ b/syllabus/syllabus.md
@@ -46,7 +46,7 @@ See the [class materials](../materials/index.md) for all of the lecture videos.
 *Discussion*: **ONLINE**. See [Discussion](#discussion) for more information.
 
 Discussion will take place online via Zoom.
-See the [Discussion section](syllabus/syllabus.md#discussion) of the syllabus for more details.
+See the [Discussion section](#discussion) of the syllabus for more details.
 
 ### Instructor
 


### PR DESCRIPTION
The link to the discussion section on the syllabus was creating a 404 error due to the link not being quite correct. 